### PR TITLE
Fix #6

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
         // Create default launcher folder if needed
         let launcher_dir = lib::consts::launcher_dir().expect("Failed to get launcher dir");
 
-        if !Path::new(&launcher_dir).exists() || Path::new(&format!("{}/.first-run", launcher_dir)).exists() {
+        if !Path::new(&launcher_dir).exists() || !Path::new(&format!("{}/.first-run", launcher_dir)).exists() {
             fs::create_dir_all(&launcher_dir).expect("Failed to create default launcher dir");
             fs::write(format!("{}/.first-run", launcher_dir), "").expect("Failed to create .first-run file");
 


### PR DESCRIPTION
In main.rs the application should show a first_run dialog if it is first run. However, that is not the case in certain conditions. 
main.rs line 74 says
``` Rust
if !Path::new(&launcher_dir).exists() || Path::new(&format!("{}/.first-run", launcher_dir)).exists() {
```
I think this means if the launcher_dir exists, but the .first-run file does not, then whole the condition returns false and therefore the first_run won't be executed. I think the intent here is that you show the first_run if the launcher_dir folder does not exist or if the .first_run file does not exist.
E.g. like this:
``` Rust
if !Path::new(&launcher_dir).exists() || !Path::new(&format!("{}/.first-run", launcher_dir)).exists() {
```

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>