### PR TITLE
Added option to change game path from preferences.

### DIFF
--- a/assets/ui/preferences/general.blp
+++ b/assets/ui/preferences/general.blp
@@ -37,7 +37,18 @@ Adw.PreferencesPage page {
             }
         }
     }
+    Adw.PreferencesGroup {
+        title: "Game Location";
 
+        Adw.EntryRow game_location {
+            title: "Game Folder";
+			
+        }
+
+        Adw.EntryRow game_temporary_location {
+            title: "Temporary Download Location";
+        }
+    }
     Adw.PreferencesGroup {
         title: "Status";
 

--- a/src/ui/main.rs
+++ b/src/ui/main.rs
@@ -299,7 +299,11 @@ impl App {
                             glib::MainContext::default().invoke(move || {
                                 this.update(Actions::PreferencesGoBack).unwrap();
 
-                                this.toast("Failed to update preferences", err);
+                                this.toast("Failed to update preferences. Resetting game path preferences.", err);
+                                let mut config = config::get().unwrap();
+                                config.game.path = consts::launcher_dir().unwrap().join("game/drive_c/Program Files/Genshin Impact");
+                                config.game.path = consts::launcher_dir().unwrap();
+                                config::update(config);
                             });
                         }
                     });
@@ -1070,6 +1074,10 @@ impl App {
                         glib::MainContext::default().invoke(move || {
                             this.toast("Failed to get initial launcher state", err);
                         });
+                        let mut config = config::get().unwrap();
+                        config.game.path = consts::launcher_dir().unwrap().join("game/drive_c/Program Files/Genshin Impact");
+                        config.launcher.temp = consts::launcher_dir();
+                        config::update(config);
                     }
                 }
             });


### PR DESCRIPTION
- Can change game location and temporary download location from the preferences menu.
- Resets to default location upon errors to prevent bricking the launcher. (I need suggestions on how to do this cleaner and better)

`self.widgets.game_temporary_location.set_text(&config.launcher.temp.unwrap().into_os_string().into_string().unwrap());`
Suggest changes with this line, this is very very bad.

